### PR TITLE
Upgrade scrpage2 to scrlayer-scrpage

### DIFF
--- a/documentation/musicexamples.tex
+++ b/documentation/musicexamples.tex
@@ -202,7 +202,7 @@ Great effort has been put into the handling of examples starting on odd or even 
 
 The handling of the caption is somewhat special with this command.
 The caption -- which isn't a real \cmd{caption} but just text used as such -- is printed in the header or footer of the (first) page of the example.
-This is realized through the use of the \package{scrpage2} package from \package{KOMA-Script}.
+This is realized through the use of the \package{scrlayer-scrpage} package from \package{KOMA-Script}.
 The pagestyle for the first page is set to the predefined \env{xmpPageOne} while the remaining pages are assigned \env{xmpPageTwo}.
 By default the caption is printed on the left (or inner) part of the header of the first page, while the page number is centered in the footer.
 The caption is styled manually within this page style and defaults to the default \cmd{caption} format.
@@ -354,10 +354,10 @@ Starting examples on odd or even pages is fully supported.
 \item[\cmd{setXmpListName}]Set the Title for the list of music examples.
 \item[\cmd{setXmpAlignment}] Set the alignment for all subsequent music examples.
 To modify the alignment of a single example use standard \LaTeX{} commands inside the environment.
-\item[\env{xmpPageOne} and \env{xmpPageTwo}]Page styles used (by \package{scrpage2}) for the first and the remaining pages of a full/multi page example. 
+\item[\env{xmpPageOne} and \env{xmpPageTwo}]Page styles used (by \package{scrlayer-scrpage}) for the first and the remaining pages of a full/multi page example. 
 Typically prints the caption in the header or footer of the first page.
 The caption has to be manually made consistent with the standard captions.
-To change the layout use the \cmd{deftripstyle} command from the \package{scrpage2} package.
+To change the layout use the \cmd{deftripstyle} command from the \package{scrlayer-scrpage} package.
 \item[\env{\{xmp:\}}] Suggested prefix for labels.
 There are \package{fancyref} labels defined for this prefix.
 \end{description} 

--- a/musicexamples.sty
+++ b/musicexamples.sty
@@ -47,7 +47,7 @@
 % See the documentation of the packages for more information
 
 % Allow definition of new pagestyles for fullpage examples
-\RequirePackage{scrpage2}
+\RequirePackage{scrlayer-scrpage}
 
 % Start fullpage example on next page
 \RequirePackage{afterpage}
@@ -330,7 +330,7 @@
 
 % With full-page examples the numbering and caption is realized
 % using the header/footer of the first (or only) page
-% (by use of scrpage2 from KOMA-Script).
+% (by use of scrlayer-scrpage from KOMA-Script).
 % The following predefined pagestyles places the caption
 % in the inner/left part of the header (for the first page) 
 % and the page number centered in the footer.
@@ -434,7 +434,7 @@
 % next or the next odd/even page.
 % If no file is found a warning is printed and the list entry colored red.
 % The caption is printed in the header or footer of the (first) page
-% using the scrpage2 mechanism.
+% using the scrlayer-scrpage mechanism.
 % The \pagestyle for the first page is set to "xmpPageOne",
 % while the \pagestyle for any following page is set to "xmpPageTwo".
 %


### PR DESCRIPTION
Hi Urs,

Many thanks for the great work done over this and lyluatex lately.

Using `musicexamples` in a `classicthesis` context (I will share the code soon), I got the following error, which this PR fixes:

```
(/home/pn/texmf/tex/latex/musicexamples/musicexamples.sty
(/usr/local/texlive/2019/texmf-dist/tex/latex/caption/newfloat.sty)
(/usr/local/texlive/2019/texmf-dist/tex/latex/koma-script/scrpage2.sty

Package scrpage2 Warning: usage of obsolete package!
(scrpage2)                Package `scrpage2' is obsolete.
(scrpage2)                You should not longer use package `scrpage2'.
(scrpage2)                You should replace usage of package `scrpage2'
(scrpage2)                by `scrlayer-scrpage' on input line 52.

! LaTeX Error: Command \scr@fnt@headtopline already defined.
               Or name \end... illegal, see p.192 of the manual.
```

I also replaced occurrences of the package name here and there.